### PR TITLE
Fix build durations by parsing build HTML instead of relying on the JSON API.

### DIFF
--- a/jenkins_exporter.py
+++ b/jenkins_exporter.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 
+from pprint import pprint
+import argparse
 import collections
 import re
-import time
 import requests
-import argparse
-from pprint import pprint
+import time
 
 import os
 from sys import exit


### PR DESCRIPTION
The Jenkins JSON API doesn't return build durations _while the build is running_. This PR parses the build status page, where the build duration is displayed (although at increasingly coarser resolutions as the build runs).

@ala-ableton ptal!