### PR TITLE
Move supervisor pin to 3.3.1-1+deb9u1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2-slim
 
 RUN apt-get update \
- && apt-get install -y supervisor=3.0r1-1+deb8u1 --no-install-recommends \
+ && apt-get install -y supervisor=3.3.1-1+deb9u1 --no-install-recommends \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
Looks like the underlying Docker container has an updated version now.

@ala-ableton, @eta-ableton, @nre-ableton, @rco-ableton ptal!